### PR TITLE
Fix typos in project descriptions

### DIFF
--- a/games.html
+++ b/games.html
@@ -156,7 +156,7 @@ https://templatemo.com/tm-532-next-level
                 <div class="text-content">
                   <h3 class="tm-text-secondary tm-mb-5">Pokedex</h3>
                   <p class="tm-mb-5">
-                    A pokedex executible that runs within the Windows environment. Utilizes a Pokemon API to provide basic information, images, and sounds of the Japanese Pocket Monsters. Writen in Python.
+                    A pokedex executable that runs within the Windows environment. Utilizes a Pokemon API to provide basic information, images, and sounds of the Japanese Pocket Monsters. written in Python.
                   </p>
                   <p class="tm-mb-5">
                     Project can be found at <a href="https://github.com/Peytonjc/pokedex">https://github.com/Peytonjc/pokedex</a>

--- a/projects.html
+++ b/projects.html
@@ -159,7 +159,7 @@ https://templatemo.com/tm-532-next-level
                 <div class="text-content">
                   <h3 class="tm-text-secondary tm-mb-5">Pokedex</h3>
                   <p class="tm-mb-5">
-                    A pokedex executible that runs within the Windows environment. Utilizes a Pokemon API to provide basic information, images, and sounds of the Japanese Pocket Monsters. Writen in Python.
+                    A pokedex executable that runs within the Windows environment. Utilizes a Pokemon API to provide basic information, images, and sounds of the Japanese Pocket Monsters. written in Python.
                   </p>
                   <p class="tm-mb-5">
                     Project can be found at <a href="https://github.com/Peytonjc/pokedex">https://github.com/Peytonjc/pokedex</a>


### PR DESCRIPTION
## Summary
- correct minor typos in the Pokedex project description

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687e9b39cb088322b5091be3c3e14ef0