### PR TITLE
Improve mobile layout for 72Seasons pages

### DIFF
--- a/72Seasons/index.html
+++ b/72Seasons/index.html
@@ -31,6 +31,12 @@
             font-size: 0.9rem;
             color: #999;
         }
+
+        @media (max-width: 600px) {
+            article {
+                padding: 0.75rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/72Seasons/seasons/0722.html
+++ b/72Seasons/seasons/0722.html
@@ -4,87 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kirikodokoki - Lesser Heat</title>
-  <style>
-    body {
-      background-color: #f8f5f0;
-      font-family: "Georgia", "Times New Roman", serif;
-      color: #333;
-      margin: 0;
-      padding: 0;
-    }
-    .container {
-      max-width: 1000px;
-      margin: 2rem auto;
-      padding: 2rem;
-      background: #fdfbf7;
-      background-image: url('/img/72Seasons/paper-texture.jpg'); /* subtle washi texture */
-      background-size: cover;
-      box-shadow: 0 0 10px rgba(0,0,0,0.1);
-    }
-    .header {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 2rem;
-    }
-    .header img {
-      width: 220px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-    }
-    .title-section {
-      flex: 1;
-      margin-left: 1.5rem;
-    }
-    h1 {
-      font-size: 2.8rem;
-      margin: 0;
-      color: #2f2f2f;
-    }
-    h2 {
-      font-size: 1.4rem;
-      font-style: italic;
-      color: #666;
-      margin-top: 0.5rem;
-    }
-    .dates {
-      font-size: 1rem;
-      color: #999;
-      margin-top: 0.5rem;
-    }
-    .content {
-      display: flex;
-      flex-direction: row;
-      gap: 2rem;
-    }
-    .main-text {
-      flex: 2;
-      font-size: 1.1rem;
-      line-height: 1.8;
-    }
-    .poem {
-      flex: 1;
-      font-size: 1rem;
-      font-style: italic;
-      color: #555;
-      border-left: 2px solid #ddd;
-      padding-left: 1rem;
-    }
-    .poem .kanji {
-      writing-mode: vertical-rl;
-      font-family: "Hiragino Mincho ProN", serif;
-      font-size: 1.2rem;
-      color: #444;
-      margin-bottom: 1rem;
-    }
-    footer {
-      text-align: center;
-      margin-top: 3rem;
-      font-size: 0.9rem;
-      color: #aaa;
-    }
-  </style>
+  <link rel="icon" type="image/x-icon" href="/img/icon/ramenStand.ico" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP&display=swap" />
+  <link rel="stylesheet" href="/72Seasons/shared/72SeasonsStyle.css" />
 </head>
 <body>
   <div class="container">

--- a/72Seasons/shared/72SeasonsStyle.css
+++ b/72Seasons/shared/72SeasonsStyle.css
@@ -112,3 +112,33 @@ footer a {
 footer a:hover {
   text-decoration: underline;
 }
+
+/* Mobile layout tweaks */
+@media (max-width: 600px) {
+  .container {
+    padding: 1rem;
+    margin: 1rem auto;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .header img {
+    width: 100%;
+    max-width: 180px;
+    margin-bottom: 1rem;
+  }
+
+  .content {
+    flex-direction: column;
+  }
+
+  .poem {
+    border-left: none;
+    border-top: 2px solid #ddd;
+    padding-left: 0;
+    padding-top: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive styles in `72SeasonsStyle.css`
- hook July 22 microseason post to the shared stylesheet
- tweak index page article padding on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687eb5cae12c83228d97251df1d79154