### PR TITLE
Add August 13 microseason draft and index sidebar

### DIFF
--- a/72Seasons/index.html
+++ b/72Seasons/index.html
@@ -11,7 +11,7 @@
     <style>
         main {
             display: grid;
-            grid-template-columns: 1fr;
+            grid-template-columns: 3fr 1fr;
             gap: 1.5rem;
         }
         article {
@@ -31,8 +31,34 @@
             font-size: 0.9rem;
             color: #999;
         }
-
+        .sidebar {
+            background-color: rgba(255, 255, 255, 0.8);
+            padding: 1rem;
+            box-shadow: 0 0 5px rgba(0,0,0,0.05);
+            height: fit-content;
+        }
+        .sidebar ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .sidebar li {
+            margin-bottom: 0.5rem;
+        }
+        .sidebar a {
+            color: #2f2f2f;
+            text-decoration: none;
+        }
+        .sidebar a:hover {
+            text-decoration: underline;
+        }
         @media (max-width: 600px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+            .sidebar {
+                margin-top: 1rem;
+            }
             article {
                 padding: 0.75rem;
             }
@@ -50,7 +76,14 @@
         </header>
 
         <main>
-            <section>
+            <section class="recent-posts">
+                <!--
+                <article>
+                    <h2><a href="seasons/0813.html">Evening Cicadas Sing</a></h2>
+                    <time datetime="2025-08-13">around August 13</time>
+                    <p>Early Autumn</p>
+                </article>
+                -->
                 <article>
                     <h2><a href="seasons/0807.html">Cool Wind Rises Again</a></h2>
                     <time datetime="2025-08-07">around August 7</time>
@@ -66,13 +99,18 @@
                     <time datetime="2025-07-28">around July 28</time>
                     <p>Greater Heat</p>
                 </article>
-                <article>
-                    <h2><a href="seasons/0722.html">Paulownia Trees Produce Seeds</a></h2>
-                    <time datetime="2025-07-22">around July 22</time>
-                    <p>Greater Heat</p>
-                </article>
-                <!-- More seasons will be added here -->
             </section>
+            <aside class="sidebar">
+                <h2>All Posts</h2>
+                <ul>
+                    <li><a href="seasons/0807.html">Cool Wind Rises Again</a></li>
+                    <li><a href="seasons/0801.html">Heavy Rain May Fall</a></li>
+                    <li><a href="seasons/0728.html">Damp Earth, Humid Heat</a></li>
+                    <li><a href="seasons/0722.html">Paulownia Trees Produce Seeds</a></li>
+                    <li><a href="seasons/0717.html">Kirikodokoki</a></li>
+                    <!-- <li><a href="seasons/0813.html">Evening Cicadas Sing</a></li> -->
+                </ul>
+            </aside>
         </main>
 
         <footer>

--- a/72Seasons/seasons/0813.html
+++ b/72Seasons/seasons/0813.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Evening Cicadas Sing - Early Autumn</title>
+  <link rel="icon" type="image/x-icon" href="/img/icon/ramenStand.ico" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP&display=swap" />
+  <link rel="stylesheet" href="/72Seasons/shared/72SeasonsStyle.css" />
+</head>
+<body>
+  <div class="container">
+    <!-- Header Section -->
+    <div class="header">
+      <img src="/img/72Seasons/72SeasonIndexImage.jpeg" alt="Summer countryside at dusk" />
+      <div class="title-section">
+        <h1>Evening cicadas sing</h1>
+        <h2>Early Autumn</h2>
+        <div class="dates">August 13 – August 17</div>
+      </div>
+    </div>
+
+    <!-- Back Link -->
+    <div class="back-to-index">
+      <a href="/72Seasons/index.html">← Back to Index</a>
+    </div>
+
+    <!-- Main Content -->
+    <div class="content">
+      <div class="main-text">
+        <p>
+          The sun still presses hard through the afternoon, but at dusk the air shifts. From the trees comes a thin, insistent chorus—the call of <em>higurashi</em> cicadas that rise and fall like waves.
+        </p>
+        <p>
+          寒蝉鳴 (<em>Higurashi naku</em>), literally “cold cicadas sing,” marks the second micro season of <em>Risshū</em>. These evening voices are a traditional sign that summer has begun to loosen its grip, even if the heat lingers long after sunset.
+        </p>
+        <p>
+          The sound is bittersweet. Children chase the last fireflies, while commuters pause at crossings as the cicadas echo off concrete. In poetry and folklore, the higurashi's song is a reminder that time is slipping forward.
+        </p>
+        <p>
+          Listening, it's easy to feel suspended between seasons—held for a moment in the amber of twilight before the next day's heat arrives.
+        </p>
+      </div>
+
+      <div class="poem">
+        <div class="kanji">
+          閑さや<br/>
+          岩にしみ入る<br/>
+          蝉の声
+        </div>
+        <p><strong>Such stillness</strong><br/>
+           the cicadas' cry sinks<br/>
+           into the rocks</p>
+        <p>– <a href="https://en.wikipedia.org/wiki/Matsuo_Bash%C5%8D">Bashō</a></p>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+      Part of the 72 Microseasons series – Exploring the subtle shifts of the Japanese year.<br/>
+      <a href="/72Seasons/index.html">Back to Index</a>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Draft post for August 13–17 “Evening cicadas sing” microseason
- Limit homepage to three recent posts and add sidebar with links to all seasons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899f715c9b48322951f308b6e0260df